### PR TITLE
[RDY] Fix 2 more bugs related to #29

### DIFF
--- a/src/GhciFind.hs
+++ b/src/GhciFind.hs
@@ -266,8 +266,8 @@ resolveSpanInfo :: [SpanInfo] -> Int -> Int -> Int -> Int -> Maybe SpanInfo
 resolveSpanInfo spanList parentSL parentSC parentEL parentEC =
   find contains spanList
   where contains (SpanInfo ancestorSL ancestorSC ancestorEL ancestorEC _ _) =
-          ((ancestorSL == parentSL && parentSC >= ancestorSC) || (ancestorSL > parentSL)) &&
-          ((ancestorEL == parentEL && parentEC <= ancestorEC) || (ancestorEL < parentEL))
+          ((ancestorSL == parentSL && parentSC >= ancestorSC) || (ancestorSL < parentSL)) &&
+          ((ancestorEL == parentEL && parentEC <= ancestorEC) || (ancestorEL > parentEL))
 
 -- | Guess a module name from a file path.
 guessModule :: GhcMonad m

--- a/src/GhciFind.hs
+++ b/src/GhciFind.hs
@@ -263,11 +263,11 @@ findType infos fp string sl sc el ec =
 
 -- | Try to resolve the type display from the given span.
 resolveSpanInfo :: [SpanInfo] -> Int -> Int -> Int -> Int -> Maybe SpanInfo
-resolveSpanInfo spanList parentSL parentSC parentEL parentEC =
+resolveSpanInfo spanList spanSL spanSC spanEL spanEC =
   find contains spanList
   where contains (SpanInfo ancestorSL ancestorSC ancestorEL ancestorEC _ _) =
-          ((ancestorSL == parentSL && parentSC >= ancestorSC) || (ancestorSL < parentSL)) &&
-          ((ancestorEL == parentEL && parentEC <= ancestorEC) || (ancestorEL > parentEL))
+          ((ancestorSL == spanSL && spanSC >= ancestorSC) || (ancestorSL < spanSL)) &&
+          ((ancestorEL == spanEL && spanEC <= ancestorEC) || (ancestorEL > spanEL))
 
 -- | Guess a module name from a file path.
 guessModule :: GhcMonad m

--- a/src/GhciFind.hs
+++ b/src/GhciFind.hs
@@ -9,7 +9,6 @@ module GhciFind
   (findType,FindType(..),findLoc,findNameUses)
   where
 
-import           Control.Applicative
 import           Control.Exception
 import           Data.List
 import           Data.Map (Map)
@@ -265,11 +264,8 @@ findType infos fp string sl sc el ec =
 -- | Try to resolve the type display from the given span.
 resolveSpanInfo :: [SpanInfo] -> Int -> Int -> Int -> Int -> Maybe SpanInfo
 resolveSpanInfo spanList parentSL parentSC parentEL parentEC =
-  find inside (reverse spanList) <|> find contains spanList
-  where inside (SpanInfo childSL childSC childEL childEC _ _) =
-          ((childSL == parentSL && childSC >= parentSC) || (childSL > parentSL)) &&
-          ((childEL == parentEL && childEC <= parentEC) || (childEL < parentEL))
-        contains (SpanInfo ancestorSL ancestorSC ancestorEL ancestorEC _ _) =
+  find contains spanList
+  where contains (SpanInfo ancestorSL ancestorSC ancestorEL ancestorEC _ _) =
           ((ancestorSL == parentSL && parentSC >= ancestorSC) || (ancestorSL > parentSL)) &&
           ((ancestorEL == parentEL && parentEC <= ancestorEC) || (ancestorEL < parentEL))
 

--- a/src/test/Main.hs
+++ b/src/test/Main.hs
@@ -109,6 +109,10 @@ types =
                      "https://github.com/chrisdone/intero/issues/29"
                      (typeAt testFile (1,26,1,35,"\"aa\" \"bb\"")
                              "\"aa\" \"bb\" :: [Char] -> [Char]\n")
+               -- TODO: see what to do about <text> param when multi-line input.
+               it ":type-at 2 lines within a do bloc"
+                     (typeAt testFile (4,8,5,10,"{{multiline}}")
+                     "{{multiline}} :: IO ()\n")
                it ":type-at part of a line within a do bloc (1)"
                      (typeAt testFile (4,8,4,10," 1") " 1 :: IO ()\n")
                it ":type-at part of a line within a do bloc (2)"

--- a/src/test/Main.hs
+++ b/src/test/Main.hs
@@ -108,7 +108,14 @@ types =
                      (typeAt "test = putStrLn (concat3 \"aa\" \"bb\" \"cc\")\n\
                               \concat3 a b c = a ++ b ++ c"
                              (1,18,1,28,"concat3 \"a")
-                             "concat3 \"a :: [Char] -> [Char] -> [Char]\n"))
+                             "concat3 \"a :: [Char] -> [Char] -> [Char]\n")
+               issue ":type-at for 2 complete arguments of a function"
+                     "https://github.com/chrisdone/intero/issues/29"
+                     (typeAt "test = putStrLn (concat3 \"aa\" \"bb\" \"cc\")\n\
+                              \concat3 a b c = a ++ b ++ c"
+                             (1,26,1,35,"\"aa\" \"bb\"")
+                             "\"aa\" \"bb\" :: [Char] -> [Char]\n"))
+
 
 -- | List all types in all modules loaded.
 alltypes :: Spec

--- a/src/test/Main.hs
+++ b/src/test/Main.hs
@@ -97,24 +97,34 @@ types =
                issue ":type-at X.hs 1 1 1 1 x -- Char (oddly bounded selection)"
                      "https://github.com/chrisdone/intero/issues/29"
                      (typeAt "foo = 'a'" (1,1,1,1,"f") "f :: Char\n")
-               issue ":type-at for two strings with oddly bounded selection"
+               issue ":type-at half of 2 arguments within function call"
                      "https://github.com/chrisdone/intero/issues/29"
-                     (typeAt "test = putStrLn (concat3 \"aa\" \"bb\" \"cc\")\n\
-                              \concat3 a b c = a ++ b ++ c"
-                             (1,29,1,32,"\" \"")
+                     (typeAt testFile (1,29,1,32,"\" \"")
                              "\" \" :: [Char] -> [Char]\n")
-               issue ":type-at for funtion with half of its first argument"
+               issue ":type-at funtion + half of its first argument"
                      "https://github.com/chrisdone/intero/issues/29"
-                     (typeAt "test = putStrLn (concat3 \"aa\" \"bb\" \"cc\")\n\
-                              \concat3 a b c = a ++ b ++ c"
-                             (1,18,1,28,"concat3 \"a")
+                     (typeAt testFile (1,18,1,28,"concat3 \"a")
                              "concat3 \"a :: [Char] -> [Char] -> [Char]\n")
-               issue ":type-at for 2 complete arguments of a function"
+               issue ":type-at 2 arguments within a function call"
                      "https://github.com/chrisdone/intero/issues/29"
-                     (typeAt "test = putStrLn (concat3 \"aa\" \"bb\" \"cc\")\n\
-                              \concat3 a b c = a ++ b ++ c"
-                             (1,26,1,35,"\"aa\" \"bb\"")
-                             "\"aa\" \"bb\" :: [Char] -> [Char]\n"))
+                     (typeAt testFile (1,26,1,35,"\"aa\" \"bb\"")
+                             "\"aa\" \"bb\" :: [Char] -> [Char]\n")
+               it ":type-at part of a line within a do bloc (1)"
+                     (typeAt testFile (4,8,4,10," 1") " 1 :: IO ()\n")
+               it ":type-at part of a line within a do bloc (2)"
+                     (typeAt testFile (4,9,4,10,"1") "1 :: Integer\n"))
+
+  where
+    testFile :: String
+    testFile =
+      unlines [ "test = putStrLn (concat3 \"aa\" \"bb\" \"cc\")"
+              , "concat3 a b c = a ++ b ++ c"
+              , "foo = do"
+              , "  print 1"
+              , "  print 2"
+              , "  print 3"
+              , ""
+              ]
 
 
 -- | List all types in all modules loaded.

--- a/src/test/Main.hs
+++ b/src/test/Main.hs
@@ -102,7 +102,13 @@ types =
                      (typeAt "test = putStrLn (concat3 \"aa\" \"bb\" \"cc\")\n\
                               \concat3 a b c = a ++ b ++ c"
                              (1,29,1,32,"\" \"")
-                             "\" \" :: [Char] -> [Char]\n"))
+                             "\" \" :: [Char] -> [Char]\n")
+               issue ":type-at for funtion with half of its first argument"
+                     "https://github.com/chrisdone/intero/issues/29"
+                     (typeAt "test = putStrLn (concat3 \"aa\" \"bb\" \"cc\")\n\
+                              \concat3 a b c = a ++ b ++ c"
+                             (1,18,1,28,"concat3 \"a")
+                             "concat3 \"a :: [Char] -> [Char] -> [Char]\n"))
 
 -- | List all types in all modules loaded.
 alltypes :: Spec


### PR DESCRIPTION
@chrisdone 

While investigating the 2 more "incorrect" results given by :type-at (found when reproducing examples pictures in #29), I grew the intuition that `inside` was not needed at all in src/GhciFind.hs.

- :type-at for the “f a” part of “f a b c” was returning the type of f
- :type-at for the “a b” part of “f a b c” was returning the the type of a
- logic was duplicated 

Indeed, `contains` seems to be the correct logic in all cases, because we always want to find the smallest enclosing type (that was also the behaviour on the web based fpcomplete haskell center ide)

Previsouly, `inside` was always matching the special case where child and parent were the same.

I'll add adding more tests to check that it behave as ghc-mod, but I think the logic is better now.
(the test suite is passing on my laptop). 

