### PR TITLE
Add libtinfo installation instructions for Fedora derivatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,12 @@ Key binding | Description
 
 ## Install requirements
 
-Make sure you have this package installed on Linux:
+Make sure you have `libtinfo` installed:
 
-    libtinfo-dev
+OS | Package
+--- | ---
+Debian derivatives | `libtinfo-dev`
+Fedora derivatives | `ncurses-devel`
 
 (People on other platforms please contribute the equivalent
 dependency.)


### PR DESCRIPTION
### Reason

The `README.md` uses `libtinfo-dev` as a package name of `libtinfo` for GNU/Linux. While the name is valid for Debian-based distros, other distros put the library into a different package. 

### Changes

- Explicitly mention `libtinfo-dev` as a package for Debian derivatives.
- Add package name that installs `libtinfo` on Fedora derivatives.