### PR TITLE
Bump GHC upper bound to 8.6.4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+0.1.39:
+	* Support for GHC 8.6.4
 0.1.38:
 	* Fix bug of getting encoding for networked queries
 

--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -72,9 +72,9 @@
 (defcustom intero-package-version
   (cl-case system-type
     ;; Until <https://github.com/haskell/network/issues/313> is fixed:
-    (windows-nt "0.1.38")
-    (cygwin "0.1.38")
-    (t "0.1.38"))
+    (windows-nt "0.1.39")
+    (cygwin "0.1.39")
+    (t "0.1.39"))
   "Package version to auto-install.
 
 This version does not necessarily have to be the latest version

--- a/intero.cabal
+++ b/intero.cabal
@@ -1,7 +1,7 @@
 name:
   intero
 version:
-  0.1.38
+  0.1.39
 synopsis:
   Complete interactive development program for Haskell
 license:
@@ -73,7 +73,7 @@ executable intero
     bytestring,
     directory,
     filepath,
-    ghc >= 7.8 && <= 8.6.3,
+    ghc >= 7.8 && <= 8.6.4,
     ghc-paths,
     haskeline,
     process,

--- a/src/test/Main.hs
+++ b/src/test/Main.hs
@@ -419,7 +419,7 @@ completion = do
              (atFile
                 ":complete-at"
                 "X.hs"
-                         -- All these type annotations are required for GHC 8.6.3
+                         -- All these type annotations are required for GHC 8.6.4
                          -- to accept the input without error.
                 "{-# OPTIONS -fdefer-type-errors #-}\nmodule X where\ng a = fiiila (filu :: Char) a (fi :: Int)\n where fiiila _ _ _ = 123"
                 (2, 14, 2, 17, "fi")

--- a/test/test-ghcs
+++ b/test/test-ghcs
@@ -1,11 +1,11 @@
 set -e
 
-# Test GHC 8.6.3
+# Test GHC 8.6.4
 
-echo GHC 8.6.3 ...
+echo GHC 8.6.4 ...
 stack clean
-stack setup --resolver lts-13.1
-stack build . --resolver lts-13.1 --test --force-dirty --ghc-options=-fforce-recomp
+stack setup --resolver lts-13.11
+stack build . --resolver lts-13.11 --test --force-dirty --ghc-options=-fforce-recomp
 
 # Test GHC 8.4.1
 


### PR DESCRIPTION
Well, nothing much to say. The upgrade from 8.6.3 to 8.6.4 is pretty much about the change in the upperbound.