### PR TITLE
Use `fno-code fwrite-interface` when GHC >= 8.4.1

### DIFF
--- a/src/GhciInfo.hs
+++ b/src/GhciInfo.hs
@@ -70,7 +70,11 @@ collectInfo ms loaded =
             Nothing -> return True
             Just mi ->
               do let fp =
+#if MIN_VERSION_ghc(8,0,4)
+                       ml_hi_file (ms_location (modinfoSummary mi))
+#else
                        ml_obj_file (ms_location (modinfoSummary mi))
+#endif
                      last' = modinfoLastUpdate mi
                  exists <- doesFileExist fp
                  if exists


### PR DESCRIPTION
This should fix #627.

A couple of points/questions:

* Does this mean that other editor integrations now need to follow the switching logic, on pain of intero not correctly tracking when files have been loaded?
* I've checked that the elisp compiles, but I'm afraid I'm too much of an emacs noob to test this locally. I tried `M-x install-file` but got errors when intero tried to install itself. Sorry about that.

> Before this commit, we pass `-fobject-code` to ghci, which produces
> build artifacts (object files). This allows subsequent reloads to be
> faster and improves the performance of intero.
> 
> It is possible to output interface files while only doing the work of
> typechecking with the flags `fno-code` and `fwrite-interface`. This,
> again, improves the performance of intero.
> 
> Unfortunately, `fno-code` does not work well with Template Haskell
> before GHC version 8.4.1. Therefore, we switch which flags we provide
> based on version number.