### PR TITLE
Remove broken exec arg --tty=false

### DIFF
--- a/elisp/intero.el
+++ b/elisp/intero.el
@@ -2432,7 +2432,7 @@ default when nil)."
             (list "--stack-yaml" stack-yaml))
           (list "--with-ghc"
                 with-ghc
-                "--docker-run-args=--interactive=true --tty=false"
+                "--docker-run-args=--interactive=true"
                 )
           (when no-build
             (list "--no-build"))


### PR DESCRIPTION
After updating `stack` and `intero` to the latest versions, I wasn't able to run a repl inside spacemacs anymore because I'd get the following error:

```
Invalid option `--tty=false'

Usage: stack ghci [TARGET/FILE] [--pedantic] [--ghci-options OPTIONS]
                  [--ghc-options OPTIONS] [--flag PACKAGE:[-]FLAG]
                  [--with-ghc GHC] [--[no-]load] [--package ARG]
                  [--main-is TARGET] [--load-local-deps] [--[no-]package-hiding]
                  [--only-main] [--trace] [--profile] [--no-strip] [--[no-]test]
                  [--[no-]bench] [--help]
  Run ghci in the context of package(s) (experimental)

---

This is the buffer where Emacs talks to intero. It's normally hidden,
but a problem occcured.

TROUBLESHOOTING

It may be obvious if there is some text above this message
indicating a problem.

If you do not wish to use Intero for some projects, see
https://github.com/commercialhaskell/intero#whitelistingblacklisting-projects

The process ended. Here is the reason that Emacs gives us:

  exited abnormally with code 1

For troubleshooting purposes, here are the arguments used to launch intero:

  stack ghci --with-ghc /home/emanuel/.asdf/installs/haskell/8.6.5/stack/compiler-tools/x86_64-linux-tinfo6/ghc-8.6.5/bin/intero "--docker-run-args=--interactive=true --tty=false" --no-build --no-load --ghci-options -ignore-dot-ghci hs-web
```

Note that I'm using the following versions
- `stack 2.1.3`
- `intero 0.1.40`

Running the suggested troubleshooting command reproduces the error